### PR TITLE
Fix issues #3 and #4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,9 @@
+## 0.1.1
+ - Fix issue #4, where fields specified by `fields => ` were added to events if
+   they were not present.
+ - Fixed a bug where objects (nested fields) were not properly deleted if there
+   were multiple levels and each had a dotted field name.
+ - Fix issue #3, where dynamic fields are not recognized properly because of the
+   instance variable.
 ## 0.1.0
  - Initial release

--- a/lib/logstash/filters/de_dot.rb
+++ b/lib/logstash/filters/de_dot.rb
@@ -36,6 +36,26 @@ class LogStash::Filters::De_dot < LogStash::Filters::Base
   end # def register
 
   private
+  def find_fieldref_for_delete(source)
+    # In cases where fieldref may look like [a.b][c.d][e.f], we only want to delete
+    # the first level at which the dotted field appears.
+    fieldref = ''
+    @logger.debug? && @logger.debug("de_dot: source fieldref for delete", :source => source)
+    # Iterate over each level of source
+    source.delete('[').split(']').each do |ref|
+      fieldref = fieldref + '['
+      if !(ref =~ /\./).nil?
+        # return when we find the first ref with a '.'
+        @logger.debug? && @logger.debug("de_dot: fieldref for delete", :fieldref => fieldref + ref + ']')
+        return fieldref + ref + ']'
+      else
+        fieldref = fieldref + ref + ']'
+        @logger.debug? && @logger.debug("de_dot: fieldref still building", :fieldref => fieldref)
+      end
+    end
+  end
+
+  private
   def rename_field(event, fieldref)
     @logger.debug? && @logger.debug("de_dot: preprocess", :event => event.to_hash.to_s)
     if @separator == ']['
@@ -49,7 +69,7 @@ class LogStash::Filters::De_dot < LogStash::Filters::Base
     @logger.debug? && @logger.debug("de_dot: replacement field reference", :newref => newref)
     event[newref] = event[fieldref]
     @logger.debug? && @logger.debug("de_dot: event with both new and old field references", :event => event.to_hash.to_s)
-    event.remove(fieldref)
+    event.remove(find_fieldref_for_delete(fieldref))
     @logger.debug? && @logger.debug("de_dot: postprocess", :event => event.to_hash.to_s)
   end
 
@@ -57,9 +77,17 @@ class LogStash::Filters::De_dot < LogStash::Filters::Base
   def filter(event)
     @separator = '][' if @nested
     @logger.debug? && @logger.debug("de_dot: Replace dots with separator", :separator => @separator)
-    @fields = event.to_hash.keys if @fields.nil?
-    @logger.debug? && @logger.debug("de_dot: Act on these fields", :fields => @fields)
-    @fields.each { |ref| rename_field(event, ref) if !(ref =~ /\./).nil? }
+    if @fields.nil?
+      fields = event.to_hash.keys
+    else
+      fields = @fields
+    end
+    @logger.debug? && @logger.debug("de_dot: Act on these fields", :fields => fields)
+    fields.each do |ref|
+      if event[ref]
+        rename_field(event, ref) if !(ref =~ /\./).nil?
+      end
+    end
     filter_matched(event)
   end # def filter
 end # class LogStash::Filters::De_dot

--- a/lib/logstash/filters/de_dot.rb
+++ b/lib/logstash/filters/de_dot.rb
@@ -28,6 +28,10 @@ class LogStash::Filters::De_dot < LogStash::Filters::Base
   #
   config :fields, :validate => :array
 
+  public
+  def has_dot?(fieldref)
+    fieldref =~ /\./
+  end
 
   public
   def register
@@ -44,7 +48,7 @@ class LogStash::Filters::De_dot < LogStash::Filters::Base
     # Iterate over each level of source
     source.delete('[').split(']').each do |ref|
       fieldref = fieldref + '['
-      if !(ref =~ /\./).nil?
+      if has_dot?(ref)
         # return when we find the first ref with a '.'
         @logger.debug? && @logger.debug("de_dot: fieldref for delete", :fieldref => fieldref + ref + ']')
         return fieldref + ref + ']'
@@ -85,7 +89,7 @@ class LogStash::Filters::De_dot < LogStash::Filters::Base
     @logger.debug? && @logger.debug("de_dot: Act on these fields", :fields => fields)
     fields.each do |ref|
       if event[ref]
-        rename_field(event, ref) if !(ref =~ /\./).nil?
+        rename_field(event, ref) if has_dot?(ref)
       end
     end
     filter_matched(event)

--- a/logstash-filter-de_dot.gemspec
+++ b/logstash-filter-de_dot.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-de_dot'
-  s.version         = '0.1.0'
+  s.version         = '0.1.1'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This filter removes dots from field names and replaces them with a different separator."
   s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/de_dot_spec.rb
+++ b/spec/filters/de_dot_spec.rb
@@ -128,8 +128,37 @@ describe LogStash::Filters::De_dot do
       expect(event['[acme][roller][skates]']).to eq('coyote')
       expect(event.to_hash.keys).not_to include('foo.bar')
       expect(event['[foo][bar]']).to eq('nochange')
-      expect(event.to_hash.keys).not_to include('a.a')
+      expect(event.to_hash.keys).not_to include('a.b')
       expect(event['[a][b][c][d][e][f]']).to eq('finally')
+    end
+  end
+
+  describe "Multiple specific nested fields with some not present" do
+    let(:config) {
+      {
+        "nested" => true,
+        "fields" => [ "[acme][roller.skates]", "foo.bar", "[a.b][c.d][e.f]" ]
+      }
+    }
+    let(:attrs) {
+      {
+        "acme" => { "roller.skates" => "coyote" },
+        "a.b" => { "c.d" => { "e.f" => "finally"} }
+      }
+    }
+
+    it "should replace all dots with underscores within specified fields" do
+      subject.filter(event)
+      expect(event['acme']).not_to include('roller.skates')
+      expect(event['[acme][roller][skates]']).to eq('coyote')
+      expect(event.to_hash.keys).not_to include('a.b')
+      expect(event['[a][b][c][d][e][f]']).to eq('finally')
+    end
+
+    it "should not add [foo][bar]" do
+      subject.filter(event)
+      expect(event.to_hash.keys).not_to include('foo.bar')
+      expect(event.to_hash.keys).not_to include('foo')
     end
   end
 


### PR DESCRIPTION
Check for the existence of a field to prevent accidentally adding an empty fieldref to events
where the `fields` directive is used.

Use a local variable instead of the instance variable to allow dynamic fields to be properly assessed.

fixes #3
fixes #4
