### PR TITLE
Process keys with falsey values

### DIFF
--- a/lib/logstash/filters/de_dot.rb
+++ b/lib/logstash/filters/de_dot.rb
@@ -88,7 +88,7 @@ class LogStash::Filters::De_dot < LogStash::Filters::Base
     end
     @logger.debug? && @logger.debug("de_dot: Act on these fields", :fields => fields)
     fields.each do |ref|
-      if event[ref]
+      if event.to_hash.key?(ref)
         rename_field(event, ref) if has_dot?(ref)
       end
     end


### PR DESCRIPTION
Change the guard condition when processing fields in an event to check
for key existence rather than value truthiness. Without this change,
a key that does exist but which happens to have a value that jruby
considers to be false will not be processed.
### before

```
{
  "_index": "logstash-2016.07.09",
  "_type": "mediawiki",
  "_id": "AVXP9pmTUJNpVbIylOfp",
  "_score": null,
  "_source": {
    "message": "de-dot test",
    "@version": 1,
    "@timestamp": "2016-07-09T14:01:31.000Z",
    "type": "mediawiki",
    "host": "deployment-tin",
    "level": "INFO",
    "tags": [
      "syslog",
      "es",
      "es"
    ],
    "channel": "redis",
    "normalized_message": "de-dot test",
    "wiki": "enwiki",
    "mwversion": "1.28.0-alpha",
    "reqId": "d543772db0e9b24fa0f3a15b",
    "foo.bar.false": false,
    "private": false,
    "foo_bar_true": true,
    "foo_bar_0": 0,
    "foo_bar_1": 1
  },
  "sort": [
    1468072891000
  ]
}
```
### after

```
{
  "_index": "logstash-2016.07.09",
  "_type": "mediawiki",
  "_id": "AVXQWzkoUJNpVbIyl7NA",
  "_score": null,
  "_source": {
    "message": "de-dot test",
    "@version": 1,
    "@timestamp": "2016-07-09T15:51:26.000Z",
    "type": "mediawiki",
    "host": "deployment-tin",
    "level": "INFO",
    "tags": [
      "syslog",
      "es",
      "es"
    ],
    "channel": "redis",
    "normalized_message": "de-dot test",
    "wiki": "enwiki",
    "mwversion": "1.28.0-alpha",
    "reqId": "db6479168779a7c8b5175dbb",
    "private": false,
    "foo_bar_true": true,
    "foo_bar_false": false,
    "foo_bar_0": 0,
    "foo_bar_1": 1
  },
  "sort": [
    1468079486000
  ]
}
```
