### PR TITLE
Add support for resursive searching of sub-fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.1.0
+  - Add support for recursively searching sub-fields with the new `recusive =>`
+    config option
 # 1.0.0
   - Depend on the correct version of logstash-core-plugin-api to work with
     Logstash 5.0

--- a/logstash-filter-de_dot.gemspec
+++ b/logstash-filter-de_dot.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-de_dot'
-  s.version         = '1.0.0'
+  s.version         = '1.1.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This filter removes dots from field names and replaces them with a different separator."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This allows sub-fields to be converted recursively. Given the potential for this to be _really_ slow, it's recommended to only use it when specifying specific `fields` to search.

Fixes #7 
