### PR TITLE
Add support for resursive searching of sub-fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+  - Add support for recursively searching sub-fields with the new `recusive =>`
+    config option
+
 ## 1.0.4
   - fix failure of fieldnames with boolean value "false" #9
 

--- a/lib/logstash/filters/de_dot.rb
+++ b/lib/logstash/filters/de_dot.rb
@@ -67,20 +67,12 @@ class LogStash::Filters::De_dot < LogStash::Filters::Base
 
   private
   def rename_field(event, fieldref)
-    @logger.debug? && @logger.debug("de_dot: preprocess", :event => event.to_hash.to_s)
     if @separator == '][' || @recursive
       @logger.debug? && @logger.debug("de_dot: fieldref pre-process", :fieldref => fieldref)
       fieldref = '[' + fieldref if fieldref[0] != '['
       fieldref = fieldref + ']' if fieldref[-1] != ']'
       @logger.debug? && @logger.debug("de_dot: fieldref bounding square brackets should exist now", :fieldref => fieldref)
     end
-    @logger.debug? && @logger.debug("de_dot: source field reference", :fieldref => fieldref)
-    newref = fieldref.gsub('.', @separator)
-    @logger.debug? && @logger.debug("de_dot: replacement field reference", :newref => newref)
-    event.set(newref, event.get(fieldref))
-    @logger.debug? && @logger.debug("de_dot: event with both new and old field references", :event => event.to_hash.to_s)
-    event.remove(find_fieldref_for_delete(fieldref))
-    @logger.debug? && @logger.debug("de_dot: postprocess", :event => event.to_hash.to_s)
 
     if has_dot?(fieldref)
       @logger.debug? && @logger.debug("de_dot: preprocess", :event => event.to_hash.to_s)

--- a/lib/logstash/filters/de_dot.rb
+++ b/lib/logstash/filters/de_dot.rb
@@ -19,10 +19,16 @@ class LogStash::Filters::De_dot < LogStash::Filters::Base
   # a different separator.
   config :nested, :validate => :boolean, :default => false
 
+  # If `recursive` is _true_, then recursively check sub-fields. It is recommended you
+  # only use this when specifying specific fields.
+  config :recursive, :validate => :boolean, :default => false
+
   # The `fields` array should contain a list of known fields to act on.
   # If undefined, all top-level fields will be checked.  Sub-fields must be
   # manually specified in the array.  For example: `["field.suffix","[foo][bar.suffix]"]`
   # will result in "field_suffix" and nested or sub field ["foo"]["bar_suffix"]
+  #
+  # To check all sub-fields, enable recursive checking.
   #
   # WARNING: This is an expensive operation.
   #
@@ -62,7 +68,7 @@ class LogStash::Filters::De_dot < LogStash::Filters::Base
   private
   def rename_field(event, fieldref)
     @logger.debug? && @logger.debug("de_dot: preprocess", :event => event.to_hash.to_s)
-    if @separator == ']['
+    if @separator == '][' || @recursive
       @logger.debug? && @logger.debug("de_dot: fieldref pre-process", :fieldref => fieldref)
       fieldref = '[' + fieldref if fieldref[0] != '['
       fieldref = fieldref + ']' if fieldref[-1] != ']'
@@ -75,6 +81,27 @@ class LogStash::Filters::De_dot < LogStash::Filters::Base
     @logger.debug? && @logger.debug("de_dot: event with both new and old field references", :event => event.to_hash.to_s)
     event.remove(find_fieldref_for_delete(fieldref))
     @logger.debug? && @logger.debug("de_dot: postprocess", :event => event.to_hash.to_s)
+
+    if has_dot?(fieldref)
+      @logger.debug? && @logger.debug("de_dot: preprocess", :event => event.to_hash.to_s)
+      @logger.debug? && @logger.debug("de_dot: source field reference", :fieldref => fieldref)
+      newref = fieldref.gsub('.', @separator)
+      @logger.debug? && @logger.debug("de_dot: replacement field reference", :newref => newref)
+      event.set(newref, event.get(fieldref))
+      @logger.debug? && @logger.debug("de_dot: event with both new and old field references", :event => event.to_hash.to_s)
+      event.remove(find_fieldref_for_delete(fieldref))
+      @logger.debug? && @logger.debug("de_dot: postprocess", :event => event.to_hash.to_s)
+      fieldref = newref
+    end
+
+    if @recursive
+      @logger.debug? && @logger.debug("de_dot: recursively process field reference", :fieldref => fieldref)
+      if event.get(fieldref).is_a?(Hash)
+        event.get(fieldref).keys.each do |ref|
+          rename_field(event, fieldref + '[' + ref + ']')
+        end
+      end
+    end
   end
 
   public
@@ -89,7 +116,7 @@ class LogStash::Filters::De_dot < LogStash::Filters::Base
     @logger.debug? && @logger.debug("de_dot: Act on these fields", :fields => fields)
     fields.each do |ref|
       if event.include?(ref)
-        rename_field(event, ref) if has_dot?(ref)
+        rename_field(event, ref) if has_dot?(ref) || @recursive
       end
     end
     filter_matched(event)

--- a/logstash-filter-de_dot.gemspec
+++ b/logstash-filter-de_dot.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-de_dot'
-  s.version         = '1.0.4'
+  s.version         = '1.1.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Computationally expensive filter that removes dots from a field name"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/de_dot_spec.rb
+++ b/spec/filters/de_dot_spec.rb
@@ -234,4 +234,99 @@ describe LogStash::Filters::De_dot do
     end
   end
 
+  describe "Recusive processing" do
+    let(:config) { { "recursive" => true } }
+    let(:attrs) { { "acme" => { "roller.skates" => "coyote", "nodot" => "nochange" } } }
+
+    it "should replace dots in sub-fields to underscores" do
+      subject.filter(event)
+      expect(event.to_hash['acme'].keys).not_to include('roller.skates')
+      expect(event.get('[acme][roller_skates]')).to eq('coyote')
+    end
+
+    it "should not change a field without dots" do
+      subject.filter(event)
+      expect(event.to_hash['acme'].keys).to include('nodot')
+      expect(event.get('[acme][nodot]')).to eq('nochange')
+    end
+  end
+
+  describe "Recusive processing with nested fields" do
+    let(:config) { { "recursive" => true, "nested" => true } }
+    let(:attrs) { { "acme" => { "roller.skates" => "coyote", "nodot" => "nochange" } } }
+
+    it "should convert dotted sub-fields to nested sub-fields" do
+      subject.filter(event)
+      expect(event.to_hash['acme'].keys).not_to include('roller.skates')
+      expect(event.get('[acme][roller][skates]')).to eq('coyote')
+    end
+
+    it "should not change a field without dots" do
+      subject.filter(event)
+      expect(event.to_hash['acme'].keys).to include('nodot')
+      expect(event.get('[acme][nodot]')).to eq('nochange')
+    end
+  end
+
+  describe "Recusive processing with deeply nested fields" do
+    let(:config) { { "recursive" => true, "nested" => true } }
+    let(:attrs) { { "acme" => { "super.duper" => { "roller.skates" => "coyote", "nodot" => "nochange" } } } }
+
+    it "should convert dotted sub-fields to nested sub-fields" do
+      subject.filter(event)
+      expect(event.to_hash['acme'].keys).not_to include('super.duper')
+      expect(event.get('[acme][super][duper]').keys).not_to include('roller.skates')
+      expect(event.get('[acme][super][duper][roller][skates]')).to eq('coyote')
+    end
+
+    it "should not change a field without dots" do
+      subject.filter(event)
+      expect(event.get('[acme][super][duper]').keys).to include('nodot')
+      expect(event.get('[acme][super][duper][nodot]')).to eq('nochange')
+    end
+  end
+
+  describe "Recusive processing with specific nested fields" do
+    let(:config) { { "recursive" => true, "nested" => true, "fields" => [ "acme" ] } }
+    let(:attrs) { { "acme" => { "roller.skates" => "coyote" }, "foo.bar" => "nochange" } }
+
+    it "should convert dotted sub-fields to nested sub-fields within specified fields" do
+      subject.filter(event)
+      expect(event.to_hash['acme'].keys).not_to include('roller.skates')
+      expect(event.get('[acme][roller][skates]')).to eq('coyote')
+    end
+
+    it "should not change a field not listed, even with dots" do
+      subject.filter(event)
+      expect(event.to_hash.keys).to include('foo.bar')
+      expect(event.get('foo.bar')).to eq('nochange')
+    end
+  end
+
+  describe "Recusive processing with multiple specific nested fields" do
+    let(:config) {
+      {
+          "recursive" => true,
+          "nested" => true,
+          "fields" => [ "acme", "foo.bar", "a.b" ]
+      }
+    }
+    let(:attrs) {
+      {
+          "acme" => { "roller.skates" => "coyote" },
+          "foo.bar" => "nochange",
+          "a.b" => { "c.d" => { "e.f" => "finally"} }
+      }
+    }
+
+    it "should convert all dotted fields to sub-fields within specified fields" do
+      subject.filter(event)
+      expect(event.get('acme')).not_to include('roller.skates')
+      expect(event.get('[acme][roller][skates]')).to eq('coyote')
+      expect(event.to_hash.keys).not_to include('foo.bar')
+      expect(event.get('[foo][bar]')).to eq('nochange')
+      expect(event.to_hash.keys).not_to include('a.b')
+      expect(event.get('[a][b][c][d][e][f]')).to eq('finally')
+    end
+  end
 end


### PR DESCRIPTION
This allows sub-fields to be converted recursively. Given the potential for this to be really slow, it's recommended to only use it when specifying specific fields to search.

Fixes #7.

This fixes the merge conflicts of the original pull request #13.
