### PR TITLE
Tag with error the events that generates an error in de_dotting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.0
+  - Add support to tag on failures when de_dot filter encounter a problem during the processing of the event [#26](https://github.com/logstash-plugins/logstash-filter-de_dot/pull/26)
+
 ## 1.1.0
   - Add support for recursively searching sub-fields with the new `recusive =>` config option [#24](https://github.com/logstash-plugins/logstash-filter-de_dot/pull/24)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -39,6 +39,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-nested>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-recursive>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-separator>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-tag_on_failure>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -84,6 +85,14 @@ only use this when setting specific fields, as this is an expensive operation.
   * Default value is `"_"`
 
 Replace dots with this value.
+
+[id="plugins-{type}s-{plugin}-tag_on_failure"]
+===== `tag_on_failure`
+
+  * Value type is <<string,string>>
+  * The default value for this setting is `_mutate_error`
+
+If a failure occurs during the application of this de_dot filter, the provided tag is added to the event.
 
 
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -90,7 +90,7 @@ Replace dots with this value.
 ===== `tag_on_failure`
 
   * Value type is <<string,string>>
-  * The default value for this setting is `_mutate_error`
+  * The default value for this setting is `_de_dot_error`
 
 If a failure occurs during the application of this de_dot filter, the provided tag is added to the event.
 

--- a/lib/logstash/filters/de_dot.rb
+++ b/lib/logstash/filters/de_dot.rb
@@ -34,6 +34,9 @@ class LogStash::Filters::De_dot < LogStash::Filters::Base
   #
   config :fields, :validate => :array
 
+  # Tag to apply if the operation errors
+  config :tag_on_failure, :validate => :string, :default => '_de_dot_error'
+
   public
   def has_dot?(fieldref)
     fieldref =~ /\./
@@ -113,5 +116,10 @@ class LogStash::Filters::De_dot < LogStash::Filters::Base
       end
     end
     filter_matched(event)
+  rescue => ex
+    meta = { :exception => ex.message }
+    meta[:backtrace] = ex.backtrace if logger.debug?
+    logger.warn('Exception caught while applying de_dot filter', meta)
+    event.tag(@tag_on_failure)
   end # def filter
 end # class LogStash::Filters::De_dot

--- a/logstash-filter-de_dot.gemspec
+++ b/logstash-filter-de_dot.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-de_dot'
-  s.version         = '1.1.0'
+  s.version         = '1.2.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Computationally expensive filter that removes dots from a field name"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/de_dot_spec.rb
+++ b/spec/filters/de_dot_spec.rb
@@ -92,11 +92,29 @@ describe LogStash::Filters::De_dot do
     context "when nested fields overlaps scalar fields" do
       let(:config) { { "nested" => true } }
       let(:attrs) { { "request" => "GET", "request.path" => "/users" } }
-      let(:expected_tag) { '_de_dot_error' }
 
-      it "should tag the event as failed" do
-        subject.filter(event)
-        expect(event.get('tags')).to include(expected_tag)
+      shared_examples('catch and tag error') do
+        let(:expected_tag) { '_de_dot_error' }
+
+        context 'when the event is filtered' do
+          before(:each) { subject.filter(event) }
+
+          it 'tags the event with the expected tag' do
+            expect(event).to include('tags')
+            expect(event.get('tags')).to include(expected_tag)
+          end
+        end  
+      end  
+
+      context "when `tag_on_failure` is not provided" do
+        include_examples "catch and tag error"
+      end
+
+      context "when `tag_on_failure` is provided" do
+        include_examples "catch and tag error" do
+          let(:expected_tag) { "_my_custom_error" }
+          let(:config) { super().merge("tag_on_failure" => expected_tag) }
+        end
       end
     end
   end

--- a/spec/filters/de_dot_spec.rb
+++ b/spec/filters/de_dot_spec.rb
@@ -88,6 +88,17 @@ describe LogStash::Filters::De_dot do
       expect(event.to_hash.keys).to include('nodot')
       expect(event.get('nodot')).to eq('nochange')
     end
+    
+    context "when nested fields overlaps scalar fields" do
+      let(:config) { { "nested" => true } }
+      let(:attrs) { { "request" => "GET", "request.path" => "/users" } }
+      let(:expected_tag) { '_de_dot_error' }
+
+      it "should tag the event as failed" do
+        subject.filter(event)
+        expect(event.get('tags')).to include(expected_tag)
+      end
+    end
   end
 
   describe "Specific nested field" do


### PR DESCRIPTION
## Release notes
Apply an 'error' tag to any event that fails the de-dotting process.

## What does this PR do?

Covers with a rescue clause the de-dotting filter execution so that each event that cause a runtime error on this is tagged with appropriate error and doesn't crash the pipeline.

## Why is it important/What is the impact to the user?

When the de_dot filter is applied to an event that would generate a runtime error (because of conflicting event field types), this PR permit to appropriately tag the event without crashing the pipeline. In this way, the user can route the processing of such offending events to different flow that could patch the event itself or store somewhere for a future re-processing operation.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

- Configure a local clone of Logstash's `Gemfile` adding:
   
     ```
     gem "logstash-filter-de_dot", :path => "/path/to/logstash_plugins/logstash-filter-de_dot"
     ```
     
- Install the local checkout of this PR:     
   
     ```
     bin/logstash-plugin install --no-verify
     ```
     
- Test the plugin with a pipeline that uses the filter:
   
     ```
     bin/logstash -f /path/to/dedot_filter_pipeline.conf
     ```
     
## Related issues
- Closes #25 

## Logs
Log error after this patch:
```
[2026-04-28T11:48:22,674][WARN ][logstash.filters.de_dot  ][main][c941b58ac3f3f023587de9484eee6370339c112a02faae684c1b9ae39f08d801] Exception caught while applying de_dot filter {exception: "Could not set field 'path' on object 'abc' to value 'def'.This is probably due to trying to set a field like [foo][bar] = someValuewhen [foo] is not either a map or a string"}
```

Previous error
```
[2026-04-21T16:00:01,363][ERROR][logstash.javapipeline    ][main] Pipeline worker error, the pipeline will be stopped 
{pipeline_id: "main", 
exception: "Java::OrgLogstash::Accessors::InvalidFieldSetException", 
error: "Could not set field 'path' on object 'abc' to value 'def'.This is probably due to trying to set a field like [foo][bar] = someValuewhen [foo] is not either a map or a string", 
stacktrace: "org.logstash.Accessors.setChild(Accessors.java:142)
org.logstash.Accessors.set(Accessors.java:36)
org.logstash.Event.setField(Event.java:228)
org.logstash.ext.JrubyEventExtLibrary$RubyEvent.ruby_set_field(JrubyEventExtLibrary.java:125)
org.logstash.ext.JrubyEventExtLibrary$RubyEvent$INVOKER$i$2$0$ruby_set_field.call(JrubyEventExtLibrary$RubyEvent$INVOKER$i$2$0$ruby_set_field.gen)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:291)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:330)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)
org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:94)
org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:243)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:230)
org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:233)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:476)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:293)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:330)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)
org.jruby.ir.interpreter.Interpreter.INTERPRET_BLOCK(Interpreter.java:120)
org.jruby.runtime.MixedModeIRBlockBody.commonYieldPath(MixedModeIRBlockBody.java:138)
org.jruby.runtime.IRBlockBody.doYield(IRBlockBody.java:170)
org.jruby.runtime.BlockBody.yield(BlockBody.java:108)
org.jruby.runtime.Block.yield(Block.java:191)
org.jruby.RubyArray.each(RubyArray.java:2093)
org.jruby.RubyArray$INVOKER$i$0$0$each.call(RubyArray$INVOKER$i$0$0$each.gen)
org.jruby.internal.runtime.methods.JavaMethod$JavaMethodZeroBlock.call(JavaMethod.java:559)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:90)
org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:103)
org.jruby.ir.instructions.CallBase.interpret(CallBase.java:548)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:372)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)
org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:88)
org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:206)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:193)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:257)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:344)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)
org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:88)
org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:206)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:193)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:471)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:259)
org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:270)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:343)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)
org.jruby.ir.interpreter.Interpreter.INTERPRET_BLOCK(Interpreter.java:120)
org.jruby.runtime.MixedModeIRBlockBody.commonYieldPath(MixedModeIRBlockBody.java:138)
org.jruby.runtime.IRBlockBody.doYield(IRBlockBody.java:170)
org.jruby.runtime.BlockBody.yield(BlockBody.java:108)
org.jruby.runtime.Block.yield(Block.java:191)
org.jruby.RubyArray.each(RubyArray.java:2093)
org.jruby.RubyArray$INVOKER$i$0$0$each.call(RubyArray$INVOKER$i$0$0$each.gen)
org.jruby.internal.runtime.methods.JavaMethod$JavaMethodZeroBlock.call(JavaMethod.java:559)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:446)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:92)
org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:103)
org.jruby.ir.instructions.CallBase.interpret(CallBase.java:548)
org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:372)
org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)
org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:88)
org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:206)
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:193)
org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:225)
org.logstash.config.ir.compiler.FilterDelegatorExt.doMultiFilter(FilterDelegatorExt.java:133)
org.logstash.config.ir.compiler.AbstractFilterDelegatorExt.lambda$multiFilter$0(AbstractFilterDelegatorExt.java:140)
org.logstash.instrument.metrics.timer.ConcurrentLiveTimerMetric.time(ConcurrentLiveTimerMetric.java:47)
org.logstash.config.ir.compiler.AbstractFilterDelegatorExt.multiFilter(AbstractFilterDelegatorExt.java:140)
org.logstash.generated.CompiledDataset1.compute(Unknown Source)
org.logstash.config.ir.CompiledPipeline$CompiledUnorderedExecution.compute(CompiledPipeline.java:433)
org.logstash.config.ir.CompiledPipeline$CompiledUnorderedExecution.compute(CompiledPipeline.java:425)
org.logstash.execution.ObservedExecution.lambda$compute$0(ObservedExecution.java:17)
org.logstash.execution.WorkerObserver.lambda$observeExecutionComputation$0(WorkerObserver.java:39)
org.logstash.instrument.metrics.timer.ConcurrentLiveTimerMetric.time(ConcurrentLiveTimerMetric.java:47)
org.logstash.execution.WorkerObserver.lambda$executeWithTimers$1(WorkerObserver.java:50)
org.logstash.instrument.metrics.timer.ConcurrentLiveTimerMetric.time(ConcurrentLiveTimerMetric.java:47)
org.logstash.execution.WorkerObserver.executeWithTimers(WorkerObserver.java:50)
org.logstash.execution.WorkerObserver.observeExecutionComputation(WorkerObserver.java:38)
org.logstash.execution.ObservedExecution.compute(ObservedExecution.java:17)
org.logstash.execution.WorkerLoop.abortableCompute(WorkerLoop.java:113)
org.logstash.execution.WorkerLoop.run(WorkerLoop.java:86)
java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
java.base/java.lang.reflect.Method.invoke(Method.java:580)
org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(JavaMethod.java:290)
org.jruby.javasupport.JavaMethod.invokeDirect(JavaMethod.java:156)
org.jruby.java.invokers.InstanceMethodInvoker.call(InstanceMethodInvoker.java:24)
org.jruby.java.invokers.InstanceMethodInvoker.call(InstanceMethodInvoker.java:86)
org.jruby.ir.targets.indy.InvokeSite.performIndirectCall(InvokeSite.java:893)
org.jruby.ir.targets.indy.InvokeSite.invoke(InvokeSite.java:797)
Users.andreaselva.workspace.logstash_andsel.logstash_minus_core.lib.logstash.java_pipeline.️❤ {} start_workers #0(/Users/andreaselva/workspace/logstash_andsel/logstash-core/lib/logstash/java_pipeline.rb:350)
org.jruby.runtime.CompiledIRBlockBody.callDirect(CompiledIRBlockBody.java:141)
org.jruby.runtime.MixedModeIRBlockBody.callDirect(MixedModeIRBlockBody.java:105)
org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:66)
org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:60)
org.jruby.runtime.Block.call(Block.java:146)
org.jruby.RubyProc.call(RubyProc.java:394)
org.jruby.internal.runtime.RubyRunnable.run(RubyRunnable.java:123)
java.base/java.lang.Thread.run(Thread.java:1583)
```